### PR TITLE
content/es/template.json missing links.rss

### DIFF
--- a/content/es/template.json
+++ b/content/es/template.json
@@ -44,6 +44,12 @@
       "es6": "ES6",
       "faq": "FAQ",
       "faq_verbose": "Preguntas frecuentes"
-    }
+    },
+    "rss": [
+      {
+        "title": "Actualizaciones semanales (Medium)",
+        "url": "https://medium.com/feed/@iojs_es"
+      }
+    ]
   }
 }


### PR DESCRIPTION
The change on how the index is generated was addressed in #362 but it seems that the `template.json.links.rss` was missing. 

cc @edsadr @ipeluffo ¿could you please review?
Related to #175 #361